### PR TITLE
jQuery appear fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
   ],
   "dependencies": {
     "angular": "~1.2.26",
-    "jquery-appear": "~0.2.3"
+    "jquery-appear": "~0.2.2"
   }
 }


### PR DESCRIPTION
Bower throws error, because it doesn't find the version 0.2.3

```
bower not-cached    git://github.com/emn178/angular-appear.git#*
bower resolve       git://github.com/emn178/angular-appear.git#*
bower checkout      angular-appear#master
bower resolved      git://github.com/emn178/angular-appear.git#79f7753e54
bower not-cached    git://github.com/emn178/jquery-appear.git#~0.2.3
bower resolve       git://github.com/emn178/jquery-appear.git#~0.2.3
bower not-cached    git://github.com/angular/bower-angular.git#~1.2.26
bower resolve       git://github.com/angular/bower-angular.git#~1.2.26
bower download      https://github.com/angular/bower-angular/archive/v1.2.29.tar.gz
bower extract       angular#~1.2.26 archive.tar.gz
bower resolved      git://github.com/angular/bower-angular.git#1.2.29
bower ENORESTARGET  No tag found that was able to satisfy ~0.2.3

Additional error details:
Available versions in git://github.com/emn178/jquery-appear.git: 0.2.2
```
